### PR TITLE
Improve support for C++ integer literals. Now supports:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # zapif
-`zapif` algebraic simplifies C proprocessor conditionals and removes code that would never be selected by the preprocessor.
+`zapif` algebraic simplifies C and C++ preprocessor conditionals, and removes code that would never be selected by the preprocessor.
 
 Unlike [`unifdef`](http://dotat.at/prog/unifdef/), `zapif` simplifies conditionals that it cannot eliminate. For example, given a file `demo.c` with:
 ```
@@ -64,6 +64,8 @@ The recognized options are:
 
 ## Limitations
 
-* Numerals are recognized as having values only if they fit in a C++
-  `long long`, follow the C conventions for decimal, octal, or hexadecimal,
-  and do not have any suffixes.
+* Numerals are recognized as having values only if they fit in a C++ `long long`,
+  and follow C++14 conventions for decimal, octal, binary, or hexadecimal literals.
+
+* Constant folding uses `long long`, even if a literal has a suffix specifying "unsigned".
+  A warning is issued if a literal has an unsigned suffix and exceeds the range of `long long`.

--- a/src/token.l
+++ b/src/token.l
@@ -36,6 +36,7 @@ HASH ^[ \t]*#[ \t]*
 LEFT_SQUOTE ([LUu]|u8)?\'
 IF_DELIM [^a-zA-Z0-9_]
 DCHAR [!"#$%&'*+,-./0-9:;<=>?@A-Z\[\\\]^_`a-z{|}~]*
+INT_SUFFIX [uU]?[lL]?[lL]?
 %%
 
 <INITIAL>{
@@ -130,8 +131,12 @@ DCHAR [!"#$%&'*+,-./0-9:;<=>?@A-Z\[\\\]^_`a-z{|}~]*
     ~{SPACE}        {RET(NOT);}
     \({SPACE}       {RET(LPAREN);}
     \)              {RET(RPAREN);}
-    [A-Za-z_0-9]+   {RET(ID);}   /* Really id or numeral */
-    [A-Za-z_0-9\$\@]+ {
+    [1-9](\'?[0-9])*{INT_SUFFIX}                    {RET(ID);} /* Decimal literal */
+    0[bB][01](\'?[01])*{INT_SUFFIX}                 {RET(ID);} /* Binary literal */
+    0(\'?[0-7])*{INT_SUFFIX}                        {RET(ID);} /* Octal literal */
+    0[xX][0-9A-Fa-f](\'?[0-9A-Fa-f])*{INT_SUFFIX}   {RET(ID);} /* Hex literal */
+    [A-Za-z_][A-Za-z_0-9]*  {RET(ID);}   /* Identifier or boolean literal */
+    [A-Za-z\$\@][A-Za-z_0-9\$\@]* {
                         if (!extendedCharMode)
                         {
                             fprintf(stderr, "%d identifer with $ or @: %s\n", yylineno, yytext);

--- a/test/literal.cpp
+++ b/test/literal.cpp
@@ -1,0 +1,15 @@
+#if 0x1234'56'789ab'cdef0 + 01'234'5'670 == 0b10'01000110100'0'10101100111100010011010111001101010101010101000
+Octal and lowercase hex and binary
+#endif
+
+#if 0X1234'56'789ABCD'EF0 + 01'234'56'70 == 0B10'010001101000'1'0101100111100010011010'1110011010'10101010101000
+Octal and uppercase hex and binary
+#endif
+
+#if 03l + 0xfll == 0b101u + 6ul + 7ull
+Lowercase suffixes
+#endif
+
+#if 03L + 0xfLL == 0b101U + 6UL + 7ULL
+Uppercase suffixes
+#endif

--- a/test/literal.kpp
+++ b/test/literal.kpp
@@ -1,0 +1,7 @@
+Octal and lowercase hex and binary
+
+Octal and uppercase hex and binary
+
+Lowercase suffixes
+
+Uppercase suffixes


### PR DESCRIPTION
* C++14 digit separators.

* C++14 binary literals.

* U, L, and LL suffixes on integer literals, though they are always treated as having type `long long`. A warning is issued when the `U` suffix is present and the value does not fit in `long long`.