### PR TITLE
Add a conan build workflow

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -30,7 +30,7 @@ jobs:
             cpp_compiler: clang++
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Update CMake
       # The linux container will be using CMake 3.31 by default, but we're using CMake 4.0 features.
@@ -78,7 +78,7 @@ jobs:
     - name: Install
       run: cmake --install ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --prefix ${{ steps.strings.outputs.build-install-dir }}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: zapif-linux-${{ matrix.c_compiler }}-${{ matrix.build_type }}
         path: ${{ steps.strings.outputs.build-install-dir }}/bin/zapif
@@ -112,7 +112,7 @@ jobs:
       CXX: ${{ matrix.cpp_compiler }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -128,7 +128,7 @@ jobs:
       # Restores the built/downloaded tool packages (flex, bison, m4, CMake) so
       # they aren't rebuilt every run. Keyed by compiler since the tools are
       # built with it; hashing conanfile.py busts the cache on a version bump.
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.conan2
         key: conan-${{ runner.os }}-${{ matrix.c_compiler }}-${{ hashFiles('conanfile.py') }}

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -83,3 +83,65 @@ jobs:
         name: zapif-linux-${{ matrix.c_compiler }}-${{ matrix.build_type }}
         path: ${{ steps.strings.outputs.build-install-dir }}/bin/zapif
         if-no-files-found: error
+
+  linux-conan:
+    # Mirrors the `build` job, but builds and packages with Conan instead of
+    # invoking CMake directly. Conan provisions flex, bison, and CMake (>= 4.0)
+    # itself via tool_requires, so the system CMake/flex/bison setup isn't needed.
+    # Produces no artifacts; this just exercises the Conan recipe.
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      # Check both release and debug builds, as well as gcc and clang.
+      matrix:
+        build_type: [Release, Debug]
+        c_compiler: [gcc, clang]
+        include:
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+
+    env:
+      # Picked up by `conan profile detect` to select the compiler.
+      CC: ${{ matrix.c_compiler }}
+      CXX: ${{ matrix.cpp_compiler }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install Conan
+      run: |
+        pip install "conan==2.29.0"
+        conan profile detect --force
+
+    - name: Cache Conan packages
+      # Restores the built/downloaded tool packages (flex, bison, m4, CMake) so
+      # they aren't rebuilt every run. Keyed by compiler since the tools are
+      # built with it; hashing conanfile.py busts the cache on a version bump.
+      uses: actions/cache@v4
+      with:
+        path: ~/.conan2
+        key: conan-${{ runner.os }}-${{ matrix.c_compiler }}-${{ hashFiles('conanfile.py') }}
+        restore-keys: |
+          conan-${{ runner.os }}-${{ matrix.c_compiler }}-
+
+    - name: Conan create
+      # Builds zapif (pulling flex, bison, and CMake as build tools), then runs
+      # the test_package smoke test. --build=missing builds any deps lacking a
+      # prebuilt binary.
+      run: conan create . -s build_type=${{ matrix.build_type }} --build=missing
+
+    - name: Trim Conan cache
+      # Drop source/build/download folders so the post-run cache save keeps only
+      # the reusable package binaries.
+      run: conan cache clean "*"

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -27,7 +27,7 @@ jobs:
             cpp_compiler: cl
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Update CMake
       # We need to use CMake 4.0 or higher, so we need to download it and stick it on the path.
@@ -74,7 +74,7 @@ jobs:
     - name: Install
       run: cmake --install ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} --prefix ${{ steps.strings.outputs.build-install-dir }}
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: zapif-windows-${{ matrix.build_type }}
         path: ${{ steps.strings.outputs.build-install-dir }}\bin\zapif.exe
@@ -100,7 +100,7 @@ jobs:
             cpp_compiler: cl
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -117,7 +117,7 @@ jobs:
       # Restores the built/downloaded tool packages (winflexbison, CMake) so they
       # aren't fetched/rebuilt every run. Hashing conanfile.py busts the cache on
       # a version bump.
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.conan2
         key: conan-${{ runner.os }}-${{ matrix.c_compiler }}-${{ hashFiles('conanfile.py') }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -79,3 +79,58 @@ jobs:
         name: zapif-windows-${{ matrix.build_type }}
         path: ${{ steps.strings.outputs.build-install-dir }}\bin\zapif.exe
         if-no-files-found: error
+
+  windows-conan:
+    # Mirrors the `build` job, but builds and packages with Conan instead of
+    # invoking CMake directly. Conan provisions winflexbison and CMake (>= 4.0)
+    # itself via tool_requires, so the manual CMake/WinFlexBison setup isn't needed.
+    # Produces no artifacts; this just exercises the Conan recipe.
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+
+      # Check both release and debug builds.
+      matrix:
+        build_type: [Release, Debug]
+        c_compiler: [cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install Conan
+      # `conan profile detect` auto-detects MSVC from the Visual Studio install.
+      run: |
+        pip install "conan==2.29.0"
+        conan profile detect --force
+
+    - name: Cache Conan packages
+      # Restores the built/downloaded tool packages (winflexbison, CMake) so they
+      # aren't fetched/rebuilt every run. Hashing conanfile.py busts the cache on
+      # a version bump.
+      uses: actions/cache@v4
+      with:
+        path: ~/.conan2
+        key: conan-${{ runner.os }}-${{ matrix.c_compiler }}-${{ hashFiles('conanfile.py') }}
+        restore-keys: |
+          conan-${{ runner.os }}-${{ matrix.c_compiler }}-
+
+    - name: Conan create
+      # Builds zapif (pulling winflexbison and CMake as build tools), then runs
+      # the test_package smoke test. --build=missing builds any deps lacking a
+      # prebuilt binary.
+      run: conan create . -s build_type=${{ matrix.build_type }} --build=missing
+
+    - name: Trim Conan cache
+      # Drop source/build/download folders so the post-run cache save keeps only
+      # the reusable package binaries.
+      run: conan cache clean "*"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 /.idea
 /build
+
+# Conan local-build artifacts
+CMakeUserPresets.json
+conanbuild*
+conanrun*
+deactivate_conan*
+/test_package/build
+/test_package/metadata

--- a/README.md
+++ b/README.md
@@ -38,9 +38,44 @@ Zapif uses CMake to build, and supports both Linux and Windows. The basic depend
 
 Building for windows still requires flex and bison. The suggested distribution is [winflexbison](https://github.com/lexxmark/winflexbison) 2.5.25 or higher.
 
+Alternatively, [Conan](https://conan.io) can provide flex, bison, and CMake automatically — see [Building with Conan](#building-with-conan) — leaving a C++11 compiler as the only tool you install yourself.
+
 # Building `zapif`
 
-Run the following comments in the `zapif` directory (this one).
+You can build either with [Conan](https://conan.io) — which provisions flex, bison,
+and CMake for you — or directly with CMake if you already have those tools installed.
+
+## Building with Conan
+
+Conan installs the required flex, bison, and CMake versions automatically (and uses
+`winflexbison` on Windows), so the only things you provide yourself are a C++11
+compiler and Conan 2:
+
+```sh
+pip install conan       # or: pipx install conan
+conan profile detect    # first time only; detects your compiler
+```
+
+Then, from the `zapif` directory (this one):
+
+```sh
+conan install . --build=missing
+conan build .
+```
+
+The executable is written to `build/Release/zapif` (or `build/<config>/zapif`).
+
+To build, package, and smoke-test `zapif` as a Conan package — for example to reuse
+it as a build tool in another project via `tool_requires` — run:
+
+```sh
+conan create .
+```
+
+## Building directly with CMake
+
+If you already have flex, bison, and CMake 4.0 or higher installed, run the following
+commands in the `zapif` directory (this one):
 
 ```sh
 cmake . -B build

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,70 @@
+import os
+
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+from conan.tools.files import copy, load
+
+required_conan_version = ">=2.0"
+
+class ZapifConan(ConanFile):
+    name = "zapif"
+    description = (
+        "Algebraically simplifies C and C++ preprocessor conditionals and "
+        "removes code that the preprocessor would never select."
+    )
+    license = "Apache-2.0"
+    # Repo-local recipe: `url` points at the project itself. When porting to
+    # conan-center-index, change `url` to the CCI repo and keep `homepage`.
+    url = "https://github.com/ArchRobison/zapif"
+    homepage = "https://github.com/ArchRobison/zapif"
+    topics = ("preprocessor", "conditional-compilation", "unifdef",
+              "code-simplification", "c", "cpp", "cli")
+    package_type = "application"
+    settings = "os", "arch", "compiler", "build_type"
+
+    exports_sources = "CMakeLists.txt", "version.txt", "LICENSE", "src/*", "test/*"
+
+    def set_version(self):
+        self.version = load(self, os.path.join(self.recipe_folder, "version.txt")).strip()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build_requirements(self):
+        if self.settings.os == "Windows":
+            self.tool_requires("winflexbison/2.5.25")
+        else:
+            self.tool_requires("flex/2.6.4")
+            self.tool_requires("bison/3.8.2")
+        self.tool_requires("cmake/[>=4.0 <5]")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, 11)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.cache_variables["BUILD_TESTING"] = False
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(self, "LICENSE",
+             src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        # Application package: nothing to compile or link against. In Conan 2 the
+        # package's bindir is added to consumers' PATH automatically.
+        self.cpp_info.includedirs = []
+        self.cpp_info.libdirs = []
+
+    def package_id(self):
+        del self.info.settings.compiler

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def test(self):
+        # zapif accepts -v (not --version); prints "zapif <version>" and exits 0.
+        self.run("zapif -v", env="conanrun")


### PR DESCRIPTION
This PR adds a Conan2 build/package pathway, which was tested on both x86 Linux and x86 Windows. It should work anywhere the necessary flex/bison deps are available.

The existing CI jobs will execute a new stage to run the conan build pathway after verifying the CMake path.